### PR TITLE
Add sys/qos.h include

### DIFF
--- a/porttime/ptmacosx_mach.c
+++ b/porttime/ptmacosx_mach.c
@@ -12,6 +12,7 @@
 
 #include "porttime.h"
 #include "sys/time.h"
+#include "sys/qos.h"
 #include "pthread.h"
 
 #ifndef NSEC_PER_MSEC


### PR DESCRIPTION
This header needed to be explicitly included in stricter build environments (such as Nix). Upstreaming this change from https://github.com/NixOS/nixpkgs/pull/160614/files#diff-a1cb530708c437cbf3649c70f42452de682e5c5cfd89126806363df86122fb04